### PR TITLE
Profile & content updates: metadata, personal data, projects, and Work section

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,10 +11,10 @@ const inter = Inter({
 export const metadata: Metadata = {
 	title: {
 		default: "Muhammad Iqbal Firdaus - Portfolio",
-		template: "%s | Iqbal Firdaus",
+		template: "%s | Muhammad Iqbal Firdaus",
 	},
 	description:
-		"Frontend developer crafting digital experiences at the intersection of design, technology, and human behavior.",
+		"Frontend & mobile developer building modern web and mobile experiences with performance-focused UI and clean developer workflows.",
 	keywords: [
 		"software engineer",
 		"frontend developer",
@@ -23,22 +23,22 @@ export const metadata: Metadata = {
 		"next.js",
 		"design systems",
 	],
-	authors: [{ name: "Iqbal Firdausk" }],
-	creator: "Iqbal Firdaus",
+	authors: [{ name: "Muhammad Iqbal Firdaus" }],
+	creator: "Muhammad Iqbal Firdaus",
 	openGraph: {
 		type: "website",
 		locale: "en_US",
 		url: "https://ikbak.vercel.app",
-		title: "Iqbal Firdaus - Portfolio",
+		title: "Muhammad Iqbal Firdaus - Portfolio",
 		description:
-			"Frontend developer crafting digital experiences at the intersection of design, technology, and human behavior.",
-		siteName: "Iqbal Firdaus Portfolio",
+			"Frontend & mobile developer building modern web and mobile experiences with performance-focused UI and clean developer workflows.",
+		siteName: "Muhammad Iqbal Firdaus Portfolio",
 	},
 	twitter: {
 		card: "summary_large_image",
-		title: "Iqbal Firdaus - Portfolio",
+		title: "Muhammad Iqbal Firdaus - Portfolio",
 		description:
-			"Frontend developer crafting digital experiences at the intersection of design, technology, and human behavior.",
+			"Frontend & mobile developer building modern web and mobile experiences with performance-focused UI and clean developer workflows.",
 	},
 	robots: {
 		index: true,

--- a/src/components/PortfolioClient.tsx
+++ b/src/components/PortfolioClient.tsx
@@ -34,6 +34,7 @@ export default function PortfolioClient({ data }: PortfolioClientProps) {
 
 					<WorkSection
 						experience={data.experience}
+						projects={data.projects}
 						onRef={(el) => observeSection("work", el)}
 					/>
 

--- a/src/components/ThemeProvider.tsx
+++ b/src/components/ThemeProvider.tsx
@@ -14,7 +14,6 @@ const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
   const [theme, setTheme] = useState<Theme>("dark");
 
-  console.log(theme);
 
   useEffect(() => {
     const savedTheme = localStorage.getItem("theme") as Theme;

--- a/src/components/sections/WorkSection.tsx
+++ b/src/components/sections/WorkSection.tsx
@@ -1,17 +1,108 @@
+import Link from "next/link";
 import type { PortfolioData } from "../../lib/data";
 import SkillTag from "../ui/SkillTag";
 
 interface WorkSectionProps {
-  experience: PortfolioData["experience"];
-  onRef: (element: HTMLElement | null) => void;
+	experience: PortfolioData["experience"];
+	projects: PortfolioData["projects"];
+	onRef: (element: HTMLElement | null) => void;
 }
 
-export default function WorkSection({ experience, onRef }: WorkSectionProps) {
-  return (
-    <section
-      id="work"
-      ref={onRef}
-      className="min-h-screen py-32 opacity-0"
-    ></section>
-  );
+export default function WorkSection({
+	experience,
+	projects,
+	onRef,
+}: WorkSectionProps) {
+	return (
+		<section id="work" ref={onRef} className="min-h-screen py-32 opacity-0">
+			<div className="space-y-16">
+				<div className="space-y-4">
+					<div className="text-sm text-muted-foreground font-mono tracking-wider">
+						WORK / EXPERIENCE
+					</div>
+					<h2 className="text-4xl lg:text-5xl font-light tracking-tight">
+						Frontend, mobile, and dashboard work
+					</h2>
+					<p className="max-w-2xl text-muted-foreground text-lg leading-relaxed">
+						CV-backed freelance experience paired with public GitHub projects that
+						show my focus on performant UI, mobile apps, IoT dashboards, and clean
+						developer workflows.
+					</p>
+				</div>
+
+				<div className="space-y-8">
+					{experience.map((item) => (
+						<article
+							key={`${item.role}-${item.company}-${item.year}`}
+							className="grid gap-4 border-t border-border pt-8 lg:grid-cols-[9rem_1fr]"
+						>
+							<div className="text-sm text-muted-foreground font-mono">
+								{item.year}
+							</div>
+
+							<div className="space-y-4">
+								<div className="flex flex-col gap-1 sm:flex-row sm:items-baseline sm:justify-between">
+									<div>
+										<h3 className="text-2xl font-light text-foreground">
+											{item.role}
+										</h3>
+										<div className="text-muted-foreground">{item.company}</div>
+									</div>
+									<div className="text-sm text-muted-foreground">{item.location}</div>
+								</div>
+
+								<p className="text-muted-foreground leading-relaxed">
+									{item.description}
+								</p>
+
+								<div className="flex flex-wrap gap-2">
+									{item.tech.map((tech) => (
+										<SkillTag key={tech} skill={tech} />
+									))}
+								</div>
+							</div>
+						</article>
+					))}
+				</div>
+
+				<div className="space-y-8">
+					<div className="space-y-3">
+						<div className="text-sm text-muted-foreground font-mono tracking-wider">
+							PUBLIC GITHUB PROJECTS
+						</div>
+						<h3 className="text-3xl font-light tracking-tight">
+							Selected repositories
+						</h3>
+					</div>
+
+					<div className="grid gap-4 md:grid-cols-2">
+						{projects.map((project) => (
+							<Link
+								key={project.title}
+								href={project.url}
+								target="_blank"
+								rel="noopener noreferrer"
+								className="group flex min-h-56 flex-col justify-between rounded-lg border border-border p-5 transition-all duration-300 hover:border-muted-foreground/50 hover:shadow-sm"
+							>
+								<div className="space-y-3">
+									<h4 className="text-xl font-light group-hover:text-muted-foreground transition-colors duration-300">
+										{project.title}
+									</h4>
+									<p className="text-sm text-muted-foreground leading-relaxed">
+										{project.description}
+									</p>
+								</div>
+
+								<div className="flex flex-wrap gap-2 pt-6">
+									{project.tech.map((tech) => (
+										<SkillTag key={tech} skill={tech} />
+									))}
+								</div>
+							</Link>
+						))}
+					</div>
+				</div>
+			</div>
+		</section>
+	);
 }

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -1,77 +1,113 @@
 export const portfolioData = {
 	personal: {
-		name: "Iqbal Firdaus",
-		role: "Software developer that love to crafting digital experiences at the intersection of design, technology, and human behavior.",
+		name: "Muhammad Iqbal Firdaus",
+		role: "Frontend & mobile developer building modern web and mobile experiences with performance-focused UI and clean developer workflows.",
 		location: "Mataram, Indonesia",
 		email: "ikbakfir@gmail.com",
+		phone: "+62 87815509168",
 		currentPosition: {
-			title: "Freelance Frontend Developer",
-			company: "",
-			period: "2024 — Present",
+			title: "Freelance Frontend & Mobile Developer",
+			company: "Remote",
+			period: "March 2024 — Present",
 		},
 	},
-	skills: ["TypeScript", "React", "Nodejs", "Esp 32"],
+	skills: [
+		"TypeScript",
+		"JavaScript",
+		"Dart",
+		"React",
+		"Next.js",
+		"Flutter",
+		"React Native",
+		"Node.js",
+		"Express.js",
+		"NestJS",
+		"Tailwind CSS",
+		"Linux",
+		"Git",
+	],
+	projects: [
+		{
+			title: "ESP32 Ward Monitor",
+			description:
+				"TypeScript-based ward monitoring project that reflects my interest in IoT dashboards and operational visibility.",
+			tech: ["TypeScript", "IoT", "ESP32"],
+			url: "https://github.com/ikbakk/esp32-ward-monitor",
+		},
+		{
+			title: "Portfolio Website",
+			description:
+				"This portfolio website, built to present my frontend, mobile, freelance, and project experience in one focused place.",
+			tech: ["TypeScript", "Next.js", "Tailwind CSS"],
+			url: "https://github.com/ikbakk/website-portofolio",
+		},
+		{
+			title: "Robokarsa Clone",
+			description:
+				"Frontend implementation practice focused on translating an existing product experience into responsive React UI.",
+			tech: ["TypeScript", "React", "UI Implementation"],
+			url: "https://github.com/ikbakk/robokarsa-clone",
+		},
+		{
+			title: "Full Stack Open Backend",
+			description:
+				"Backend submission work demonstrating Node.js API fundamentals and full-stack learning practice.",
+			tech: ["JavaScript", "Node.js", "Express.js"],
+			url: "https://github.com/ikbakk/full-stack-open-submission-part3-backend",
+		},
+	],
 	experience: [
 		{
+			year: "2025 — Present",
+			role: "Mobile Developer",
+			company: "Freelance",
+			location: "Remote",
+			description:
+				"Maintained and optimized Flutter and React Native mobile applications, implementing Figma-based features, backend API integrations, localization support, and CMS-powered dynamic content flows.",
+			tech: ["Flutter", "React Native", "Sanity CMS", "APIs", "Localization"],
+		},
+		{
+			year: "2024 — 2026",
+			role: "Web Developer",
+			company: "Freelance",
+			location: "Remote",
+			description:
+				"Delivered end-to-end web applications across analytics, restaurant, automotive, and government workflows, including modular refactors, Backend-for-Frontend patterns, secure authentication, PDF digital signing, and optimized WordPress experiences.",
+			tech: ["React", "Next.js", "SolidJS", "WordPress", "BFF", "Authentication"],
+		},
+		{
+			year: "2024 — 2025",
+			role: "Web Dashboard Developer",
+			company: "Freelance",
+			location: "Remote",
+			description:
+				"Developed real-time IoT monitoring and analytics dashboards with data visualization, reducing manual device tracking and improving operational visibility for stakeholders.",
+			tech: ["React", "MQTT", "Firebase", "Recharts", "React Query"],
+		},
+		{
 			year: "2023",
-			role: "Senior Frontend Engineer",
-			company: "Vercel",
+			role: "Full-stack Engineering Apprentice",
+			company: "Generasi Gigih 3.0",
+			location: "Indonesia",
 			description:
-				"Leading frontend architecture for developer tools and AI-powered features.",
-			tech: ["React", "TypeScript", "Next.js"],
+				"Completed an intensive full-stack engineering path, building a Spotify-inspired music web app and leading a team capstone waste management application with MongoDB and REST APIs.",
+			tech: ["React", "Express.js", "Spotify API", "MongoDB", "REST APIs"],
 		},
+	],
+	education: [
 		{
-			year: "2022",
-			role: "Frontend Engineer",
-			company: "Linear",
-			description:
-				"Built performant interfaces for project management and team collaboration.",
-			tech: ["React", "GraphQL", "Framer Motion"],
-		},
-		{
-			year: "2021",
-			role: "Full Stack Developer",
-			company: "Stripe",
-			description:
-				"Developed payment infrastructure and merchant-facing dashboard features.",
-			tech: ["Ruby", "React", "PostgreSQL"],
-		},
-		{
-			year: "2019",
-			role: "Software Engineer",
-			company: "Airbnb",
-			description:
-				"Created booking flow optimizations and host management tools.",
-			tech: ["React", "Node.js", "MySQL"],
+			school: "Universitas Mataram",
+			degree: "Electrical Engineering",
+			location: "Mataram, Indonesia",
+			period: "2017 — 2024",
 		},
 	],
 	posts: [
 		{
-			title: "The Future of Web Development",
+			title: "Building maintainable client applications",
 			excerpt:
-				"Exploring how AI and automation are reshaping the way we build for the web.",
-			date: "Dec 2024",
-			readTime: "5 min",
-		},
-		{
-			title: "Design Systems at Scale",
-			excerpt:
-				"Lessons learned from building and maintaining design systems across multiple products.",
-			date: "Nov 2024",
-			readTime: "8 min",
-		},
-		{
-			title: "Performance-First Development",
-			excerpt:
-				"Why performance should be a first-class citizen in your development workflow.",
-			date: "Oct 2024",
-			readTime: "6 min",
-		},
-		{
-			title: "The Art of Code Review",
-			excerpt:
-				"Building better software through thoughtful and constructive code reviews.",
-			date: "Sep 2024",
+				"Notes from refactoring legacy frontends into modular, scalable application architectures.",
+			date: "2025",
 			readTime: "4 min",
 		},
 	],


### PR DESCRIPTION
### Motivation
- Update the portfolio to reflect the full name, more accurate role/description, and contact details and to expose public projects alongside CV-backed experience for better showcase. 
- Improve SEO/OpenGraph/Twitter metadata consistency and remove a leftover debug log in the theme provider. 

### Description
- Updated site metadata in `src/app/layout.tsx` to use the full name, revised title/template strings, and refreshed descriptions for OpenGraph and Twitter. 
- Expanded the canonical portfolio data in `src/lib/data.ts` to include `projects`, additional `skills`, `experience`, `education`, and `phone` fields, and adjusted existing posts and entries. 
- Wired `projects` through `src/components/PortfolioClient.tsx` into a redesigned `WorkSection` at `src/components/sections/WorkSection.tsx` that renders experience and a grid of public GitHub projects using `Link` and `SkillTag`. 
- Cleaned up `src/components/ThemeProvider.tsx` by removing a stray `console.log` and preserved theme persistence logic. 

### Testing
- Ran TypeScript type-check via `tsc --noEmit` and it completed successfully. 
- Built the Next.js app via `next build` / `npm run build` and the production build succeeded. 
- Executed the test and lint targets via `npm test` and `npm run lint` and both completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36dcfaabc48321a480b7aac8c37f2e)